### PR TITLE
Add pug (formerly jade) syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ lets you view and cycle through your previous copy and paste registers on the fl
 * [vim-json](https://github.com/elzr/vim-json)
 * [vim-jst](https://github.com/briancollins/vim-jst)
 * [vim-jade](https://github.com/digitaltoad/vim-jade)
+* [vim-pug](https://github.com/digitaltoad/vim-pug)
 * [vim-jsx](https://github.com/mxw/vim-jsx)
 * [elm.vim](https://github.com/lambdatoast/elm.vim)
 

--- a/vimrc
+++ b/vimrc
@@ -130,6 +130,7 @@ else
   Plugin 'mxw/vim-jsx'
   Plugin 'lambdatoast/elm.vim'
   Plugin 'leafgarland/typescript-vim'
+  Plugin 'digitaltoad/vim-pug'
 
   "
   " Development Tool Integration


### PR DESCRIPTION
Jade was changed to [Pug](https://github.com/pugjs/pug), adding Pug here ensures both are highlighted correctly (since Jade is still prevalent in a lot of apps)